### PR TITLE
Add Minecraft module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@ DEBUG=true
 LOGLEVEL=4
 BOT_PREFIX=z-
 SECRET_KEY=<Random password for generating JWT tokens>
+HYPIXEL_API_KEY=

--- a/src/modules/minecraft/commands/hypixel.ts
+++ b/src/modules/minecraft/commands/hypixel.ts
@@ -1,0 +1,50 @@
+import { EmbedBuilder } from "zumito-framework/discord";
+import { Command, CommandArgDefinition, CommandParameters, CommandType, ServiceContainer } from "zumito-framework";
+import { config } from "../../../config/index.js";
+import { HypixelService } from "../services/HypixelService.js";
+
+export class HypixelCommand extends Command {
+    name = "hypixel";
+    description = "Shows basic Hypixel stats of a player";
+    categories = ["minecraft"];
+    args: CommandArgDefinition[] = [{
+        name: "username",
+        type: "string",
+        optional: false,
+    }];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"];
+    type = CommandType.any;
+
+    hypixel: HypixelService;
+
+    constructor() {
+        super();
+        this.hypixel = ServiceContainer.getService(HypixelService);
+    }
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const username = args.get("username");
+        if (!username) {
+            (message || interaction)?.reply({ content: trans('error'), allowedMentions: { repliedUser: false } });
+            return;
+        }
+        const player = await this.hypixel.getPlayerStats(username);
+        if (!player) {
+            (message || interaction)?.reply({ content: trans('notfound'), allowedMentions: { repliedUser: false } });
+            return;
+        }
+        const networkExp = player.networkExp || 0;
+        const level = Math.floor((Math.sqrt(2 * networkExp + 30625) / 50) - 2.5);
+        const rank = player.rank || player.newPackageRank || 'None';
+        const bedwars = player.achievements?.bedwars_level || 0;
+        const embed = new EmbedBuilder()
+            .setTitle(trans('title', { user: username }))
+            .addFields(
+                { name: trans('level'), value: `${level}` },
+                { name: trans('rank'), value: rank },
+                { name: trans('bedwars'), value: `${bedwars}` }
+            )
+            .setColor(config.colors.default);
+        (message || interaction)?.reply({ embeds: [embed], allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/minecraft/commands/server.ts
+++ b/src/modules/minecraft/commands/server.ts
@@ -1,0 +1,39 @@
+import { EmbedBuilder } from "zumito-framework/discord";
+import { Command, CommandArgDefinition, CommandParameters, CommandType } from "zumito-framework";
+import { config } from "../../../config/index.js";
+
+export class ServerCommand extends Command {
+    name = "mcserver";
+    description = "Checks the status of a Minecraft server";
+    categories = ["minecraft"];
+    args: CommandArgDefinition[] = [{
+        name: "ip",
+        type: "string",
+        optional: false,
+    }];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"];
+    type = CommandType.any;
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const ip = args.get("ip");
+        if (!ip) {
+            (message || interaction)?.reply({ content: trans('error'), allowedMentions: { repliedUser: false } });
+            return;
+        }
+        const res = await fetch(`https://api.mcsrvstat.us/2/${encodeURIComponent(ip)}`);
+        const data = await res.json().catch(() => null);
+        if (!data || !data.online) {
+            (message || interaction)?.reply({ content: trans('offline', { server: ip }), allowedMentions: { repliedUser: false } });
+            return;
+        }
+        const embed = new EmbedBuilder()
+            .setTitle(trans('title', { server: ip }))
+            .addFields(
+                { name: trans('players'), value: `${data.players.online}/${data.players.max}` },
+                { name: trans('version'), value: data.version }
+            )
+            .setColor(config.colors.default);
+
+        (message || interaction)?.reply({ embeds: [embed], allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/minecraft/commands/skin.ts
+++ b/src/modules/minecraft/commands/skin.ts
@@ -1,0 +1,30 @@
+import { EmbedBuilder } from "zumito-framework/discord";
+import { Command, CommandArgDefinition, CommandParameters, CommandType } from "zumito-framework";
+import { config } from "../../../config/index.js";
+
+export class SkinCommand extends Command {
+    name = "mcskin";
+    description = "Shows the Minecraft skin of a player";
+    categories = ["minecraft"];
+    args: CommandArgDefinition[] = [{
+        name: "username",
+        type: "string",
+        optional: false,
+    }];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"];
+    type = CommandType.any;
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const username = args.get("username");
+        if (!username) {
+            (message || interaction)?.reply({ content: trans('error'), allowedMentions: { repliedUser: false } });
+            return;
+        }
+        const embed = new EmbedBuilder()
+            .setTitle(trans('title', { user: username }))
+            .setImage(`https://mc-heads.net/body/${encodeURIComponent(username)}`)
+            .setColor(config.colors.default);
+
+        (message || interaction)?.reply({ embeds: [embed], allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/minecraft/index.ts
+++ b/src/modules/minecraft/index.ts
@@ -1,0 +1,9 @@
+import { Module, ServiceContainer, ZumitoFramework } from "zumito-framework";
+import { HypixelService } from "./services/HypixelService.js";
+
+export class MinecraftModule extends Module {
+    constructor(modulePath: string, framework: ZumitoFramework) {
+        super(modulePath);
+        ServiceContainer.addService(HypixelService, [], true);
+    }
+}

--- a/src/modules/minecraft/services/HypixelService.ts
+++ b/src/modules/minecraft/services/HypixelService.ts
@@ -1,0 +1,19 @@
+export class HypixelService {
+    async getUUID(username: string): Promise<string | null> {
+        const res = await fetch(`https://api.mojang.com/users/profiles/minecraft/${encodeURIComponent(username)}`);
+        if (!res.ok) return null;
+        const data = await res.json().catch(() => null);
+        return data?.id || null;
+    }
+
+    async getPlayerStats(username: string): Promise<any | null> {
+        const uuid = await this.getUUID(username);
+        if (!uuid) return null;
+        const apiKey = process.env.HYPIXEL_API_KEY;
+        if (!apiKey) return null;
+        const res = await fetch(`https://api.hypixel.net/player?key=${apiKey}&uuid=${uuid}`);
+        if (!res.ok) return null;
+        const data = await res.json().catch(() => null);
+        return data?.player || null;
+    }
+}

--- a/src/modules/minecraft/translations/command/hypixel/en.json
+++ b/src/modules/minecraft/translations/command/hypixel/en.json
@@ -1,0 +1,15 @@
+{
+    "description": "Shows basic Hypixel statistics of a player.",
+    "title": "Hypixel stats for {user}",
+    "level": "Level",
+    "rank": "Rank",
+    "bedwars": "BedWars Level",
+    "notfound": "Player not found.",
+    "error": "You must provide a username.",
+    "arguments": {
+        "username": { "name": "username" }
+    },
+    "args": {
+        "username": { "description": "Player username" }
+    }
+}

--- a/src/modules/minecraft/translations/command/hypixel/es.json
+++ b/src/modules/minecraft/translations/command/hypixel/es.json
@@ -1,0 +1,15 @@
+{
+    "description": "Muestra estadísticas básicas de Hypixel de un jugador.",
+    "title": "Estadísticas de Hypixel de {user}",
+    "level": "Nivel",
+    "rank": "Rango",
+    "bedwars": "Nivel de BedWars",
+    "notfound": "Jugador no encontrado.",
+    "error": "Debes proporcionar un nombre de usuario.",
+    "arguments": {
+        "username": { "name": "usuario" }
+    },
+    "args": {
+        "username": { "description": "Nombre de usuario" }
+    }
+}

--- a/src/modules/minecraft/translations/command/server/en.json
+++ b/src/modules/minecraft/translations/command/server/en.json
@@ -1,0 +1,13 @@
+{
+    "description": "Checks the status of a Minecraft server.",
+    "title": "Server {server}",
+    "players": "Players",
+    "version": "Version",
+    "offline": "The server {server} appears to be offline.",
+    "arguments": {
+        "ip": { "name": "ip" }
+    },
+    "args": {
+        "ip": { "description": "Server address" }
+    }
+}

--- a/src/modules/minecraft/translations/command/server/es.json
+++ b/src/modules/minecraft/translations/command/server/es.json
@@ -1,0 +1,13 @@
+{
+    "description": "Comprueba el estado de un servidor de Minecraft.",
+    "title": "Servidor {server}",
+    "players": "Jugadores",
+    "version": "Versión",
+    "offline": "El servidor {server} parece estar offline.",
+    "arguments": {
+        "ip": { "name": "ip" }
+    },
+    "args": {
+        "ip": { "description": "Dirección del servidor" }
+    }
+}

--- a/src/modules/minecraft/translations/command/skin/en.json
+++ b/src/modules/minecraft/translations/command/skin/en.json
@@ -1,0 +1,11 @@
+{
+    "description": "Displays the Minecraft skin of a player.",
+    "title": "{user}'s skin",
+    "error": "You must provide a Minecraft username.",
+    "arguments": {
+        "username": { "name": "username" }
+    },
+    "args": {
+        "username": { "description": "Player username" }
+    }
+}

--- a/src/modules/minecraft/translations/command/skin/es.json
+++ b/src/modules/minecraft/translations/command/skin/es.json
@@ -1,0 +1,11 @@
+{
+    "description": "Muestra la skin de un jugador de Minecraft.",
+    "title": "Skin de {user}",
+    "error": "Debes indicar un nombre de usuario de Minecraft.",
+    "arguments": {
+        "username": { "name": "usuario" }
+    },
+    "args": {
+        "username": { "description": "Nombre de usuario" }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a new Minecraft module
- provide commands to show skins, Hypixel stats and server status
- register Hypixel API service and update env example

## Testing
- `npm install` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684b0324aa0c832fb244e4797cc41809