### PR TITLE
Add vibecheck fun command

### DIFF
--- a/src/config/Images.ts
+++ b/src/config/Images.ts
@@ -4,4 +4,9 @@ export const images: any = {
     banana: 'https://media.discordapp.net/attachments/989703145686982666/1325987247140634688/banana.png?ex=677dc95b&is=677c77db&hm=b1b3c99faf58172d22e3f430f51e4269a17d33d5e59dc7c5c1b5129ffa805a66&=&format=webp&quality=lossless',
     eightBall: 'https://media.discordapp.net/attachments/989703145686982666/1325974685359542372/8ball.png?ex=677dbda8&is=677c6c28&hm=ed7b1ef10735a4bf077cf8b72a74ba4ca143fe04cbd26cf6680f744262e28918&=&format=webp&quality=lossless',
     trivia: 'https://media.discordapp.net/attachments/989703145686982666/1332384346853736498/Zumito_-_Trivia.png?ex=67985ade&is=6797095e&hm=9249cc20cd8b352ee1f130c88827f98ec77466978cdb78efaa0afd53ea2bbb87&=&format=webp&quality=lossless&width=625&height=625',
+    vibeCheck: {
+        good: 'https://media.giphy.com/media/l0MYt5jPR6QX5pnqM/giphy.gif',
+        bad: 'https://media.giphy.com/media/3o6wrvdHFbwBrUFenu/giphy.gif',
+        cursed: 'https://media.giphy.com/media/xT0xeJpnrWC4XWblEk/giphy.gif',
+    },
 }

--- a/src/modules/fun/commands/vibecheck.ts
+++ b/src/modules/fun/commands/vibecheck.ts
@@ -1,0 +1,25 @@
+import { Command, CommandParameters, CommandType } from 'zumito-framework';
+import { VibeCheckEmbedBuilder } from '../embeds/VibeCheckEmbedBuilder.ts';
+
+export class Vibecheck extends Command {
+    type = CommandType.any;
+    vibeCheckEmbedBuilder: VibeCheckEmbedBuilder;
+
+    constructor() {
+        super();
+        this.vibeCheckEmbedBuilder = new VibeCheckEmbedBuilder();
+    }
+
+    async execute({ message, interaction, guildSettings }: CommandParameters): Promise<void> {
+        const options = ['good', 'bad', 'cursed'] as const;
+        const result = options[Math.floor(Math.random() * options.length)];
+
+        const embed = this.vibeCheckEmbedBuilder.getEmbed({
+            result,
+            locale: guildSettings.locale,
+        });
+        (message || interaction)?.reply({
+            embeds: [embed],
+        });
+    }
+}

--- a/src/modules/fun/embeds/VibeCheckEmbedBuilder.ts
+++ b/src/modules/fun/embeds/VibeCheckEmbedBuilder.ts
@@ -1,0 +1,21 @@
+import { EmbedBuilder } from 'zumito-framework/discord';
+import { TranslationManager, ServiceContainer } from 'zumito-framework';
+import { config } from '../../../config/index.js';
+
+export class VibeCheckEmbedBuilder {
+    translator: TranslationManager;
+
+    constructor() {
+        this.translator = ServiceContainer.getService(TranslationManager);
+    }
+
+    getEmbed({ result, locale }: { result: 'good' | 'bad' | 'cursed'; locale: string }) {
+        const images = config.images.vibeCheck || {};
+        const imageUrl = images[result];
+        const embed = new EmbedBuilder()
+            .setDescription(this.translator.get(`vibecheck.${result}`, locale))
+            .setImage(imageUrl)
+            .setColor(config.colors.default);
+        return embed;
+    }
+}

--- a/src/modules/fun/translations/vibecheck/en.json
+++ b/src/modules/fun/translations/vibecheck/en.json
@@ -1,0 +1,6 @@
+{
+  "description": "Check today's vibe.",
+  "good": "Your vibe is good today!",
+  "bad": "Your vibe is bad today...",
+  "cursed": "Your vibe is cursed today!"
+}

--- a/src/modules/fun/translations/vibecheck/es.json
+++ b/src/modules/fun/translations/vibecheck/es.json
@@ -1,0 +1,6 @@
+{
+  "description": "Comprueba tu vibra de hoy.",
+  "good": "¡Tu vibra es buena hoy!",
+  "bad": "Tu vibra es mala hoy...",
+  "cursed": "¡Tu vibra está maldita hoy!"
+}


### PR DESCRIPTION
## Summary
- add GIF URLs for vibecheck results in config
- implement VibeCheckEmbedBuilder for vibecheck embeds
- add vibecheck command
- include English and Spanish translations for vibecheck

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b1174b074832f8046a575123d97ca