### PR TITLE
Fix config import paths

### DIFF
--- a/src/modules/fun/commands/ship.ts
+++ b/src/modules/fun/commands/ship.ts
@@ -1,6 +1,6 @@
 import { GuildMember, User, EmbedBuilder } from "zumito-framework/discord";
 import { Command, CommandParameters, CommandType, CommandArgDefinition } from "zumito-framework";
-import { config } from "../../config/index.js";
+import { config } from "../../../config/index.js";
 
 export class Ship extends Command {
     args: CommandArgDefinition[] = [

--- a/src/modules/fun/commands/simp.ts
+++ b/src/modules/fun/commands/simp.ts
@@ -1,6 +1,6 @@
 import { Command, CommandParameters, CommandType } from 'zumito-framework';
 import { EmbedBuilder } from 'zumito-framework/discord';
-import { config } from '../../config/index.js';
+import { config } from '../../../config/index.js';
 
 export class Simp extends Command {
     type = CommandType.any;


### PR DESCRIPTION
## Summary
- fix wrong relative path to config in Simp and Ship commands

## Testing
- `npx tsc --noEmit src/modules/fun/commands/ship.ts src/modules/fun/commands/simp.ts` *(fails: Cannot find module 'zumito-framework/discord')*

------
https://chatgpt.com/codex/tasks/task_e_684b32f86044832fbdf99ed824b6e1ec