### PR TITLE
Add subuser level to family tree

### DIFF
--- a/src/modules/fun/translations/familytree/en.json
+++ b/src/modules/fun/translations/familytree/en.json
@@ -1,4 +1,4 @@
 {
-  "description": "📖 Generate a simple family tree based on recent mentions.",
+  "description": "📖 Generate a two-level family tree based on recent mentions.",
   "result": "{user}'s family tree"
 }

--- a/src/modules/fun/translations/familytree/es.json
+++ b/src/modules/fun/translations/familytree/es.json
@@ -1,4 +1,4 @@
 {
-  "description": "📖 Genera un árbol genealógico sencillo basado en menciones recientes.",
+  "description": "📖 Genera un árbol genealógico de dos niveles basado en menciones recientes.",
   "result": "Árbol genealógico de {user}"
 }


### PR DESCRIPTION
## Summary
- expand family tree height and message scanning
- draw subusers for each mentioned user
- update translations to mention the extra level

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684befdc2574832f9e106b2a44036e9b