### PR TITLE
Add mcavatar command

### DIFF
--- a/src/modules/minecraft/commands/avatar.ts
+++ b/src/modules/minecraft/commands/avatar.ts
@@ -1,0 +1,29 @@
+import { EmbedBuilder } from "zumito-framework/discord";
+import { Command, CommandArgDefinition, CommandParameters } from "zumito-framework";
+import { config } from "../../../config/index.js";
+
+export class AvatarCommand extends Command {
+    name = "mcavatar";
+    description = "Shows the Minecraft avatar of a player";
+    categories = ["minecraft"];
+    args: CommandArgDefinition[] = [{
+        name: "username",
+        type: "string",
+        optional: false,
+    }];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"];
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const username = args.get("username");
+        if (!username) {
+            (message || interaction)?.reply({ content: trans('error'), allowedMentions: { repliedUser: false } });
+            return;
+        }
+        const embed = new EmbedBuilder()
+            .setTitle(trans('title', { user: username }))
+            .setImage(`https://mc-heads.net/avatar/${encodeURIComponent(username)}`)
+            .setColor(config.colors.default);
+
+        (message || interaction)?.reply({ embeds: [embed], allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/minecraft/translations/command/avatar/en.json
+++ b/src/modules/minecraft/translations/command/avatar/en.json
@@ -1,0 +1,11 @@
+{
+    "description": "Displays the Minecraft avatar of a player.",
+    "title": "{user}'s avatar",
+    "error": "You must provide a Minecraft username.",
+    "arguments": {
+        "username": { "name": "username" }
+    },
+    "args": {
+        "username": { "description": "Player username" }
+    }
+}

--- a/src/modules/minecraft/translations/command/avatar/es.json
+++ b/src/modules/minecraft/translations/command/avatar/es.json
@@ -1,0 +1,11 @@
+{
+    "description": "Muestra el avatar de un jugador de Minecraft.",
+    "title": "Avatar de {user}",
+    "error": "Debes indicar un nombre de usuario de Minecraft.",
+    "arguments": {
+        "username": { "name": "usuario" }
+    },
+    "args": {
+        "username": { "description": "Nombre de usuario" }
+    }
+}


### PR DESCRIPTION
## Summary
- provide `/mcavatar` to show only a player's Minecraft avatar
- add English and Spanish translations for the new command

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684bfc8d1a60832f8943da92cc4f06b2