### PR TITLE
Add seed explorer command

### DIFF
--- a/src/modules/minecraft/commands/seedexplorer.ts
+++ b/src/modules/minecraft/commands/seedexplorer.ts
@@ -1,0 +1,30 @@
+import { EmbedBuilder } from "zumito-framework/discord";
+import { Command, CommandArgDefinition, CommandParameters } from "zumito-framework";
+import { config } from "../../../config/index.js";
+
+export class SeedExplorerCommand extends Command {
+    name = "mcseedexplorer";
+    description = "Shows a preview of a Minecraft seed";
+    categories = ["minecraft"];
+    args: CommandArgDefinition[] = [{
+        name: "seed",
+        type: "string",
+        optional: false,
+    }];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS"];
+
+    async execute({ message, interaction, args, trans }: CommandParameters): Promise<void> {
+        const seed = args.get("seed");
+        if (!seed) {
+            (message || interaction)?.reply({ content: trans('error'), allowedMentions: { repliedUser: false } });
+            return;
+        }
+        const encodedUrl = encodeURIComponent(`https://www.chunkbase.com/apps/seed-map?seed=${encodeURIComponent(seed)}`);
+        const imageUrl = `https://image.thum.io/get/${encodedUrl}`;
+        const embed = new EmbedBuilder()
+            .setTitle(trans('title', { seed }))
+            .setImage(imageUrl)
+            .setColor(config.colors.default);
+        (message || interaction)?.reply({ embeds: [embed], allowedMentions: { repliedUser: false } });
+    }
+}

--- a/src/modules/minecraft/translations/command/seedexplorer/en.json
+++ b/src/modules/minecraft/translations/command/seedexplorer/en.json
@@ -1,0 +1,11 @@
+{
+    "description": "Displays an overview of a Minecraft seed.",
+    "title": "Preview of seed {seed}",
+    "error": "You must provide a seed.",
+    "arguments": {
+        "seed": { "name": "seed" }
+    },
+    "args": {
+        "seed": { "description": "World seed" }
+    }
+}

--- a/src/modules/minecraft/translations/command/seedexplorer/es.json
+++ b/src/modules/minecraft/translations/command/seedexplorer/es.json
@@ -1,0 +1,11 @@
+{
+    "description": "Muestra una vista previa de una seed de Minecraft.",
+    "title": "Vista previa de la seed {seed}",
+    "error": "Debes proporcionar una seed.",
+    "arguments": {
+        "seed": { "name": "seed" }
+    },
+    "args": {
+        "seed": { "description": "Seed del mundo" }
+    }
+}


### PR DESCRIPTION
## Summary
- add `/mcseedexplorer` command to preview Minecraft seeds via Chunkbase
- provide Spanish and English translations for the new command

## Testing
- `npx eslint .` *(failed: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684bfd6b7634832f89390ab638e43e21