### PR TITLE
Handle missing avatar URL

### DIFF
--- a/src/modules/roblox/commands/avatar.ts
+++ b/src/modules/roblox/commands/avatar.ts
@@ -32,6 +32,10 @@ export class RobloxAvatarCommand extends Command {
             return;
         }
         const avatarUrl = await this.roblox.getAvatarUrl(userId);
+        if (!avatarUrl) {
+            (message || interaction)?.reply({ content: trans('notfound'), allowedMentions: { repliedUser: false } });
+            return;
+        }
         const embed = new EmbedBuilder()
             .setTitle(trans('title', { user: username }))
             .setImage(avatarUrl)


### PR DESCRIPTION
## Summary
- check for empty avatar URLs before creating embed in the Roblox avatar command

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_684c000bed5c832fae53e6b9ee3d2d60