### PR TITLE
feat: add autoroles module for reaction roles

### DIFF
--- a/src/modules/autoroles/commands/autorole.ts
+++ b/src/modules/autoroles/commands/autorole.ts
@@ -1,0 +1,42 @@
+import { Command, CommandParameters, ServiceContainer } from "zumito-framework";
+import { EmbedBuilder, MessageFlags, PermissionsBitField, Role } from "zumito-framework/discord";
+import { AutoRoleService } from "../services/AutoRoleService";
+
+export class AutoroleCommand extends Command {
+    name = "autorole";
+    description = "Create an auto role message";
+    categories = ["configuration"];
+    userPermissions: bigint[] = [PermissionsBitField.Flags.ManageRoles];
+    botPermissions = ["VIEW_CHANNEL", "SEND_MESSAGES", "EMBED_LINKS", "ADD_REACTIONS", "MANAGE_ROLES"];
+    args = [
+        { name: "role", type: "role", optional: false },
+        { name: "emoji", type: "string", optional: false },
+        { name: "text", type: "string", optional: true }
+    ];
+
+    async execute({ message, interaction, args }: CommandParameters): Promise<void> {
+        const guild = message?.guild || interaction?.guild;
+        const channel: any = message?.channel || interaction?.channel;
+        const role = args.get("role") as Role;
+        const emoji = args.get("emoji") as string;
+        const text = args.get("text") as string || `React with ${emoji} to get ${role}`;
+        if (!guild || !channel || !role || !emoji) {
+            const reply = "Missing role or emoji.";
+            if (interaction) await interaction.reply({ content: reply, flags: MessageFlags.Ephemeral });
+            else if (message) await message.reply(reply);
+            return;
+        }
+        const embed = new EmbedBuilder().setDescription(text);
+        const sendOptions = { embeds: [embed], fetchReply: true } as any;
+        const sent = interaction ? await interaction.reply(sendOptions) : await message!.reply(sendOptions);
+        await sent.react(emoji).catch(() => null);
+        const service = ServiceContainer.getService(AutoRoleService) as AutoRoleService;
+        await service.addAutoRole({
+            guildId: guild.id,
+            channelId: channel.id,
+            messageId: sent.id,
+            emoji,
+            roleId: role.id
+        });
+    }
+}

--- a/src/modules/autoroles/index.ts
+++ b/src/modules/autoroles/index.ts
@@ -1,0 +1,34 @@
+import { Module, ServiceContainer } from "zumito-framework";
+import { AutoRoleService } from "./services/AutoRoleService";
+import { UserPanelNavigationService } from "@zumito-team/user-panel-module/services/UserPanelNavigationService";
+
+export class AutorolesModule extends Module {
+    constructor(modulePath: string) {
+        super(modulePath);
+        ServiceContainer.addService(AutoRoleService, [], true);
+    }
+
+    async initialize(): Promise<void> {
+        await super.initialize();
+        const navigationService = ServiceContainer.getService(UserPanelNavigationService);
+        navigationService.registerItem({
+            id: "autoroles",
+            icon: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-user-plus"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M16 19v-2a4 4 0 0 0 -4 -4h-4a4 4 0 0 0 -4 4v2" /><path d="M8 7a4 4 0 1 0 0 -8a4 4 0 0 0 0 8" /><path d="M16 11l2 2l4 -4" /></svg>`,
+            label: "Auto Roles",
+            url: "/panel/:guildId/autoroles",
+            order: 30,
+            category: "config",
+            sidebar: {
+                showDropdown: false,
+                sections: [
+                    {
+                        label: "Configuration",
+                        items: [
+                            { label: "Auto Roles", url: "/panel/:guildId/autoroles" }
+                        ]
+                    }
+                ]
+            }
+        });
+    }
+}

--- a/src/modules/autoroles/services/AutoRoleService.ts
+++ b/src/modules/autoroles/services/AutoRoleService.ts
@@ -1,0 +1,56 @@
+import { Client } from "zumito-framework/discord";
+import { ServiceContainer, ZumitoFramework } from "zumito-framework";
+
+interface AutoRoleData {
+    guildId: string;
+    channelId: string;
+    messageId: string;
+    emoji: string;
+    roleId: string;
+}
+
+export class AutoRoleService {
+    private client: Client;
+    private framework: ZumitoFramework;
+    private db: any;
+
+    constructor() {
+        this.client = ServiceContainer.getService(Client);
+        this.framework = ServiceContainer.getService(ZumitoFramework);
+        this.db = this.framework.database;
+        this.registerEvents();
+    }
+
+    private registerEvents(): void {
+        this.client.on("messageReactionAdd", async (reaction, user) => {
+            if (user.bot) return;
+            const emoji = reaction.emoji.id || reaction.emoji.name;
+            const data = await this.getAutoRole(reaction.message.id, emoji);
+            if (!data) return;
+            const guild = reaction.message.guild;
+            const member = guild?.members.cache.get(user.id);
+            const role = guild?.roles.cache.get(data.roleId);
+            if (!member || !role) return;
+            await member.roles.add(role).catch(() => null);
+        });
+        this.client.on("messageReactionRemove", async (reaction, user) => {
+            if (user.bot) return;
+            const emoji = reaction.emoji.id || reaction.emoji.name;
+            const data = await this.getAutoRole(reaction.message.id, emoji);
+            if (!data) return;
+            const guild = reaction.message.guild;
+            const member = guild?.members.cache.get(user.id);
+            const role = guild?.roles.cache.get(data.roleId);
+            if (!member || !role) return;
+            await member.roles.remove(role).catch(() => null);
+        });
+    }
+
+    async addAutoRole(data: AutoRoleData): Promise<void> {
+        await this.db.collection("autoroles").insertOne(data);
+    }
+
+    async getAutoRole(messageId: string, emoji: string): Promise<AutoRoleData | null> {
+        return await this.db.collection("autoroles").findOne({ messageId, emoji });
+    }
+}


### PR DESCRIPTION
## Summary
- add autoroles module with user panel integration
- implement service to grant or remove roles on reactions
- create command to configure reaction role messages

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm ci` *(fails: connect ENETUNREACH 140.82.114.4:443)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fcf56ea0832f9a94ecbf17b005a6