### PR TITLE
docs: add MongoDB query guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,9 @@ Estas directrices aplican a cualquier cambio en este repositorio.
 - Genera embeds, botones u otros componentes dentro de los servicios de cada módulo.
 - Organiza estos servicios en la carpeta `services` del módulo, con subcarpetas específicas como `embedBuilder`, `buttonBuilder`, etc.
 
+## Base de datos
+- No crees modelos de base de datos; realiza las consultas directamente en MongoDB.
+
 ## Internacionalización
 - Evita texto codificado; utiliza siempre el sistema de traducciones.
 - Proporciona traducciones en inglés y español para cada cadena visible por el usuario.


### PR DESCRIPTION
## Summary
- document that database models shouldn't be created and queries should be done directly to MongoDB

## Testing
- `npx eslint .` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68b611511fec832faa9c3787d63e7e68